### PR TITLE
맵에 박스가 겹쳐져 생성되는 경우 텍스쳐 깜빡임 문제 수정

### DIFF
--- a/Animon/Assets/Scenes/SampleScene.unity
+++ b/Animon/Assets/Scenes/SampleScene.unity
@@ -955,7 +955,7 @@ GameObject:
   - component: {fileID: 846188897}
   m_Layer: 0
   m_Name: Plane
-  m_TagString: Untagged
+  m_TagString: Map
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1642,9 +1642,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   boxPrefab: {fileID: 7091895288778435361, guid: a8c0849a8454be7428dad01782e0a77b,
     type: 3}
-  spawnCount: 100
-  spawnMinPos: -90
-  spawnMaxPos: 90
+  spawnCount: 150
 --- !u!65 &1926031005
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Animon/Assets/Scripts/BoxSpawner.cs
+++ b/Animon/Assets/Scripts/BoxSpawner.cs
@@ -5,29 +5,69 @@ using UnityEngine;
 public class BoxSpawner : MonoBehaviour
 {
     public GameObject boxPrefab;
-    public int spawnCount = 100;
-    public int spawnMinPos = -90;
-    public int spawnMaxPos = 90;
+    public int spawnCount = 150;
 
-    void Start()
+    private int mapSizeX;
+    private int mapSizeY;
+
+    private static T[] ShuffleArray<T>(T[] array, int seed)
     {
-        Vector3 spawnPos;
-        GameObject instance;
-        for (int i = 0; i < spawnCount; ++i)
+        System.Random prng = new System.Random(seed);
+
+        for (int i = 0; i < array.Length - 1; i++)
         {
-            spawnPos = randPosition();
-            instance = Instantiate(boxPrefab, spawnPos, Quaternion.identity);
+            int randomIndex = prng.Next(i, array.Length);
+            T tempItem = array[randomIndex];
+            array[randomIndex] = array[i];
+            array[i] = tempItem;
+        }
+
+        return array;
+    }
+    private struct Coord
+    {
+        public int x;
+        public int y;
+
+        public Coord(int _x, int _y)
+        {
+            x = _x;
+            y = _y;
         }
     }
 
-    private Vector3 randPosition()
+    private Vector3 CoordToPosition(int x, int y)
     {
-        // TOOD: 같은 위치에 생성 되지 않도록 수정 (텍스처가 겹쳐지면서 깜빡거림 발생, Z-fighting)
+        return new Vector3(-mapSizeX / 2 + x, 2.5f, -mapSizeX / 2 + y);
+    }
 
-        float xPos = Random.Range(spawnMinPos, spawnMaxPos);
-        float zPos = Random.Range(spawnMinPos, spawnMaxPos);
+    void Start()
+    {
+        GameObject mapObj = GameObject.FindWithTag("Map");
+        if (mapObj == null)
+            return;
 
-        Vector3 rndPos = new Vector3(xPos, 2.5f, zPos);
-        return rndPos;
+        mapSizeX = (int)mapObj.transform.localScale.x * 10 - 10;
+        mapSizeY = (int)mapObj.transform.localScale.z * 10 - 10;
+
+        int sacaleX = (int)boxPrefab.transform.localScale.x;
+        int sacaleY = (int)boxPrefab.transform.localScale.z;
+
+        List<Coord> tileMapCoords = new List<Coord>();
+        for (int x = 0; x < mapSizeX; x += sacaleX)
+        {
+            for (int y = 0; y < mapSizeX; y += sacaleY)
+            {
+                tileMapCoords.Add(new Coord(x, y));
+            }
+        }
+
+        Queue<Coord> shuffledTileCoords = new Queue<Coord>(ShuffleArray(tileMapCoords.ToArray(), 0));
+        for (int i = 0; i < spawnCount; ++i)
+        {
+            Coord randomCoord = shuffledTileCoords.Dequeue();
+            Vector3 spawnPos = CoordToPosition(randomCoord.x, randomCoord.y);
+            GameObject instance = Instantiate(boxPrefab, spawnPos, Quaternion.identity);
+        }
     }
 }

--- a/Animon/ProjectSettings/TagManager.asset
+++ b/Animon/ProjectSettings/TagManager.asset
@@ -5,6 +5,8 @@ TagManager:
   serializedVersion: 2
   tags:
   - Coin
+  - Box
+  - Map
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
* 수정 사항
  - 박스가 겹쳐져 생성되지 않도록 수정
  - 맵을 박스 크기의 타일로 쪼개어 박스가 생성될 타일의 인덱스를 랜덤하게 생성